### PR TITLE
Remove SubmissionSetStatus from Folder-SubmissionSet associations

### DIFF
--- a/xdstools2/src/main/webapp/toolkitx/testkit/tests/20000/update/single_fd.xml
+++ b/xdstools2/src/main/webapp/toolkitx/testkit/tests/20000/update/single_fd.xml
@@ -128,11 +128,6 @@
             classificationNode="urn:uuid:d9d542f3-6cc4-48b6-8870-ea235fbc94c2"/>
       <tag0:Association targetObject="Folder01" sourceObject="SubmissionSet01"
             associationType="HasMember">
-         <tag0:Slot name="SubmissionSetStatus">
-            <tag0:ValueList>
-               <tag0:Value>Original</tag0:Value>
-            </tag0:ValueList>
-         </tag0:Slot>
          <tag0:Slot name="PreviousVersion">
             <tag0:ValueList>
                <tag0:Value>1</tag0:Value>

--- a/xdstools2/src/main/webapp/toolkitx/testkit/tests/20000c/update/single_fd.xml
+++ b/xdstools2/src/main/webapp/toolkitx/testkit/tests/20000c/update/single_fd.xml
@@ -127,11 +127,6 @@
             classificationNode="urn:uuid:d9d542f3-6cc4-48b6-8870-ea235fbc94c2"/>
       <tag0:Association targetObject="Folder01" sourceObject="SubmissionSet01"
             associationType="HasMember">
-         <tag0:Slot name="SubmissionSetStatus">
-            <tag0:ValueList>
-               <tag0:Value>Original</tag0:Value>
-            </tag0:ValueList>
-         </tag0:Slot>
          <tag0:Slot name="PreviousVersion">
             <tag0:ValueList>
                <tag0:Value>99999</tag0:Value>

--- a/xdstools2/src/main/webapp/toolkitx/testkit/tests/20000d/update/single_fd.xml
+++ b/xdstools2/src/main/webapp/toolkitx/testkit/tests/20000d/update/single_fd.xml
@@ -128,11 +128,6 @@
             classificationNode="urn:uuid:d9d542f3-6cc4-48b6-8870-ea235fbc94c2"/>
       <tag0:Association targetObject="Folder01" sourceObject="SubmissionSet01"
             associationType="HasMember">
-         <tag0:Slot name="SubmissionSetStatus">
-            <tag0:ValueList>
-               <tag0:Value>Original</tag0:Value>
-            </tag0:ValueList>
-         </tag0:Slot>
          <tag0:Slot name="PreviousVersion">
             <tag0:ValueList>
                <tag0:Value>1</tag0:Value>

--- a/xdstools2/src/main/webapp/toolkitx/testkit/tests/20000e/update_no_ap/single_fd_no_ap.xml
+++ b/xdstools2/src/main/webapp/toolkitx/testkit/tests/20000e/update_no_ap/single_fd_no_ap.xml
@@ -128,11 +128,6 @@
             classificationNode="urn:uuid:d9d542f3-6cc4-48b6-8870-ea235fbc94c2"/>
       <tag0:Association targetObject="Folder01" sourceObject="SubmissionSet01"
             associationType="HasMember">
-         <tag0:Slot name="SubmissionSetStatus">
-            <tag0:ValueList>
-               <tag0:Value>Original</tag0:Value>
-            </tag0:ValueList>
-         </tag0:Slot>
          <tag0:Slot name="PreviousVersion">
             <tag0:ValueList>
                <tag0:Value>1</tag0:Value>


### PR DESCRIPTION
SubmissionSetStatus Slots's are only intended for SubmissionSet-Document Associations. Some update requests use this slot for a SubmissionSet-Folder Association, which is not intended.