### PR TITLE
bug-534 Allow local configuration of ConfTestsTabs.xml.

### DIFF
--- a/installation/src/main/java/gov/nist/toolkit/installation/server/Installation.java
+++ b/installation/src/main/java/gov/nist/toolkit/installation/server/Installation.java
@@ -508,11 +508,64 @@ public class Installation {
         return new File(toolkitxFile(), "interaction-sequences" + sep + "InteractionSequences.xml");
     }
 
+    /*
+        Return the Tool Tab Configuration file that is located in the default folder: $ToolkitFolder/tool-tab-configs.
+        File name is created by a concatenation:  toolId + "Tabs.xml"
+     */
     public File getToolTabConfigFile(String toolId) {
         if (toolId!=null)
             return new File(toolkitxFile(), "tool-tab-configs" + sep + toolId + "Tabs.xml");
         return null;
     }
+
+    /*
+        This method is called when the user wants to search for the Tool Tab Configuration file
+        in the (current) environment folder of the external cache. If that file does not exist, then
+        drop back and return the configuration file from the default folder.
+        If successful, file path is: "$external_cache/$environment/tool-tab-configs/$toolId" + "Tabs.xml"
+     */
+    public File getToolTabConfigFile(String environment, String toolId) {
+        if (environment == null || environment.equals("")) {
+            return getToolTabConfigFile(toolId);
+        }
+        if (toolId!=null) {
+            File environmentsRootFile=environmentFile();
+            File f = new File(environmentFile().getAbsolutePath() + sep + environment + sep + "tool-tab-configs" + sep + toolId + "Tabs.xml");
+            if (f.exists()) {
+                return f;
+            } else {
+                return getToolTabConfigFile(toolId);
+            }
+        }
+        return null;
+    }
+
+    /*
+        This method is called when the user wants to search for the Tool Tab Configuration file
+        in the test session folder of the external cache. If that file does not exist, then try
+        looking in the environment folder.
+        If successful, file path is: "$external_cache/$environment/testkits/$test_session/tool-tab-configs/$toolId" + "Tabs.xml"
+     */
+/*
+    public File getToolTabConfigFile(String environment, String testSession, String xxx, String toolId) {
+        if (environment == null || environment.equals("")) {
+            return getToolTabConfigFile(testSession);
+        }
+        if (testSession == null || testSession.equals("")) {
+            return getToolTabConfigFile(environment, toolId);
+        }
+        if (toolId!=null) {
+            File environmentsRootFile=environmentFile();
+            File f = new File(environmentFile().getAbsolutePath() + sep + environment + sep + "testkits" +sep + testSession + sep + "tool-tab-configs" + sep + toolId + "Tabs.xml");
+            if (f.exists()) {
+                return f;
+            } else {
+                return getToolTabConfigFile(environment, toolId);
+            }
+        }
+        return null;
+    }
+ */
 
     public static String defaultSessionName() { return "STANDALONE"; }
     public static String defaultServiceSessionName() { return "SERVICE"; }

--- a/xdstools2/src/main/java/gov/nist/toolkit/xdstools2/server/TabConfigLoader.java
+++ b/xdstools2/src/main/java/gov/nist/toolkit/xdstools2/server/TabConfigLoader.java
@@ -92,5 +92,10 @@ public class TabConfigLoader {
     public static TabConfig getTabConfig(String toolId) {
         return TabConfig.clone(initMap.get(toolId + "Tabs.xml"));
     }
+/*
+    public static TabConfig getTabConfig(String environment, String testSession, String toolId) {
+        return TabConfig.clone(initMap.get(toolId + "Tabs.xml"));
+    }
+ */
 
 }

--- a/xdstools2/src/main/java/gov/nist/toolkit/xdstools2/server/ToolkitServiceImpl.java
+++ b/xdstools2/src/main/java/gov/nist/toolkit/xdstools2/server/ToolkitServiceImpl.java
@@ -865,7 +865,14 @@ public class ToolkitServiceImpl extends RemoteServiceServlet implements
     @Override
     public TabConfig getToolTabConfig(GetTabConfigRequest request) throws Exception {
         String toolId = request.getToolId();
-        TabConfigLoader.init(Installation.instance().getToolTabConfigFile(toolId));
+
+        String environmentName = request.getEnvironmentName();
+        TabConfigLoader.init(Installation.instance().getToolTabConfigFile(environmentName, toolId));
+        /* Replace the two  lines above with these two lines if you want the configuration tab lookup
+         * to also consider the test session.
+        String testSessionName = request.getTestSessionName();
+        TabConfigLoader.init(Installation.instance().getToolTabConfigFile(environmentName, testSessionName, toolId));
+         */
         TabConfig tabConfigRoot = TabConfigLoader.getTabConfig(toolId);
         return tabConfigRoot;
     }
@@ -875,7 +882,13 @@ public class ToolkitServiceImpl extends RemoteServiceServlet implements
         installCommandContext(request);
 
         String toolId = request.getToolId();
-        TabConfigLoader.init(Installation.instance().getToolTabConfigFile(toolId));
+        String environmentName = request.getEnvironmentName();
+        TabConfigLoader.init(Installation.instance().getToolTabConfigFile(environmentName, toolId));
+        /* Replace the two  lines above with these two lines if you want the configuration tab lookup
+         * to also consider the test session.
+        String testSessionName = request.getTestSessionName();
+        TabConfigLoader.init(Installation.instance().getToolTabConfigFile(environmentName, testSessionName, toolId));
+         */
         TabConfig tabConfigRoot = TabConfigLoader.getTabConfig(toolId);
 
         GetCollectionRequest getCollectionRequest = new GetCollectionRequest(request, "actorcollections");


### PR DESCRIPTION
Implement a search path that first looks in the external cache in the environment folder for this file.
If not found, drop back to the standard location that is shipped with the software package.
Code is included but commented out for now that would allow you to further refine the search by test session.