### PR TITLE
Features/extend ig test infrastructure

### DIFF
--- a/registry-msg-formats/src/main/java/gov/nist/toolkit/registrymsg/common/RequestHeader.java
+++ b/registry-msg-formats/src/main/java/gov/nist/toolkit/registrymsg/common/RequestHeader.java
@@ -1,0 +1,247 @@
+package gov.nist.toolkit.registrymsg.common;
+
+import org.apache.axiom.om.OMAttribute;
+import org.apache.axiom.om.OMElement;
+
+import java.util.HashMap;
+import java.util.List;
+
+public class RequestHeader {
+//	String home;
+//	String queryId;
+//	OMElement adhocQueryElement;
+//	OMElement adhocQueryRequestElement;
+//	OMAttribute homeAtt;
+//    String patientId = null;
+//	List<String> documentEntryObjectTypeList = null;
+	OMElement omElement;
+	HashMap<String, OMElement> attributeStatement = new HashMap<>();
+	String samlAssertionID = null;
+	String samlAssertionIssueInstant = null;
+	String samlAssertionVersion = null;
+	String samlAssertionIssuer = null;
+	String samlCanonicalizationMethodAlgorithm = null;
+	String samlSignatureMethodAlgorithm = null;
+	String samlDigestMethodAlgorithm = null;
+	String samlDigestValue = null;
+	String samlSignatureValue = null;
+	String samlX509Certificate = null;
+	String samlRSAKyValueModulus = null;
+	String samlRSAKeyValueExponent = null;
+	String samlNHINHomeCommunityID = null;
+	String samlIHEHomeCommunityID = null;
+	String samlPurposeOfUseCode = null;
+	String samlPurposeOfUseCodeSystem = null;
+	String samlPurposeOfUseCSP = null;
+	String samlPurposeOfUseValidatedAttributes = null;
+
+
+	/*
+	public String getHome() {
+		return home;
+	}
+	public String getQueryId() {
+		return queryId;
+	}
+	public OMElement getAdhocQueryElement() {
+		return adhocQueryElement;
+	}
+	public OMElement getRequestHeaderElement() {
+		return adhocQueryRequestElement;
+	}
+	public OMAttribute getHomeAtt() {
+		return homeAtt;
+	}
+    public String getPatientId() { return patientId; }
+
+	public OMElement getAttributeStatementAttribute(String name) {
+		OMElement e = attributeStatement.get(name);
+		return e;
+	}
+
+	public void setAttributeStatement(HashMap<String, OMElement> attributeStatement) {
+		this.attributeStatement = attributeStatement;
+	}
+
+	public List<String> getDocumentEntryObjectTypeList() {
+		return documentEntryObjectTypeList;
+	}
+
+	 */
+	public OMElement getAttributeStatementAttribute(String name) {
+		OMElement e = attributeStatement.get(name);
+		return e;
+	}
+
+	public OMElement getOmElement() {
+		return omElement;
+	}
+
+	public void setOmElement(OMElement omElement) {
+		this.omElement = omElement;
+	}
+
+	public HashMap<String, OMElement> getAttributeStatement() {
+		return attributeStatement;
+	}
+
+	public String getSamlAssertionID() {
+		return samlAssertionID;
+	}
+
+	public void setSamlAssertionID(String samlAssertionID) {
+		this.samlAssertionID = samlAssertionID;
+	}
+
+	public String getSamlAssertionIssueInstant() {
+		return samlAssertionIssueInstant;
+	}
+
+	public void setSamlAssertionIssueInstant(String samlAssertionIssueInstant) {
+		this.samlAssertionIssueInstant = samlAssertionIssueInstant;
+	}
+
+	public String getSamlAssertionVersion() {
+		return samlAssertionVersion;
+	}
+
+	public void setSamlAssertionVersion(String samlAssertionVersion) {
+		this.samlAssertionVersion = samlAssertionVersion;
+	}
+
+	public String getSamlAssertionIssuer() {
+		return samlAssertionIssuer;
+	}
+
+	public void setSamlAssertionIssuer(String samlAssertionIssuer) {
+		this.samlAssertionIssuer = samlAssertionIssuer;
+	}
+
+	public String getSamlCanonicalizationMethodAlgorithm() {
+		return samlCanonicalizationMethodAlgorithm;
+	}
+
+	public void setSamlCanonicalizationMethodAlgorithm(String samlCanonicalizationMethodAlgorithm) {
+		this.samlCanonicalizationMethodAlgorithm = samlCanonicalizationMethodAlgorithm;
+	}
+
+	public String getSamlSignatureMethodAlgorithm() {
+		return samlSignatureMethodAlgorithm;
+	}
+
+	public void setSamlSignatureMethodAlgorithm(String samlSignatureMethodAlgorithm) {
+		this.samlSignatureMethodAlgorithm = samlSignatureMethodAlgorithm;
+	}
+
+	public String getSamlDigestMethodAlgorithm() {
+		return samlDigestMethodAlgorithm;
+	}
+
+	public void setSamlDigestMethodAlgorithm(String samlDigestMethodAlgorithm) {
+		this.samlDigestMethodAlgorithm = samlDigestMethodAlgorithm;
+	}
+
+	public String getSamlDigestValue() {
+		return samlDigestValue;
+	}
+
+	public void setSamlDigestValue(String samlDigestValue) {
+		this.samlDigestValue = samlDigestValue;
+	}
+
+	public String getSamlSignatureValue() {
+		return samlSignatureValue;
+	}
+
+	public void setSamlSignatureValue(String samlSignatureValue) {
+		this.samlSignatureValue = samlSignatureValue;
+	}
+
+	public String getSamlX509Certificate() {
+		return samlX509Certificate;
+	}
+
+	public void setSamlX509Certificate(String samlX509Certificate) {
+		this.samlX509Certificate = samlX509Certificate;
+	}
+
+	public String getSamlRSAKyValueModulus() {
+		return samlRSAKyValueModulus;
+	}
+
+	public void setSamlRSAKyValueModulus(String samlRSAKyValueModulus) {
+		this.samlRSAKyValueModulus = samlRSAKyValueModulus;
+	}
+
+	public String getSamlRSAKeyValueExponent() {
+		return samlRSAKeyValueExponent;
+	}
+
+	public void setSamlRSAKeyValueExponent(String samlRSAKeyValueExponent) {
+		this.samlRSAKeyValueExponent = samlRSAKeyValueExponent;
+	}
+
+	public String getSamlNHINHomeCommunityID() {
+		return samlNHINHomeCommunityID;
+	}
+
+	public void setSamlNHINHomeCommunityID(String samlNHINHomeCommunityID) {
+		this.samlNHINHomeCommunityID = samlNHINHomeCommunityID;
+	}
+
+	public String getSamlIHEHomeCommunityID() {
+		return samlIHEHomeCommunityID;
+	}
+
+	public void setSamlIHEHomeCommunityID(String samlIHEHomeCommunityID) {
+		this.samlIHEHomeCommunityID = samlIHEHomeCommunityID;
+	}
+
+	public String getSamlPurposeOfUseCode() {
+		return samlPurposeOfUseCode;
+	}
+
+	public void setSamlPurposeOfUseCode(String samlPurposeOfUseCode) {
+		this.samlPurposeOfUseCode = samlPurposeOfUseCode;
+	}
+
+	public String getSamlPurposeOfUseCodeSystem() {
+		return samlPurposeOfUseCodeSystem;
+	}
+
+	public void setSamlPurposeOfUseCodeSystem(String samlPurposeOfUseCodeSystem) {
+		this.samlPurposeOfUseCodeSystem = samlPurposeOfUseCodeSystem;
+	}
+
+	public String getSamlPurposeOfUseCSP() {
+		return samlPurposeOfUseCSP;
+	}
+
+	public void setSamlPurposeOfUseCSP(String samlPurposeOfUseCSP) {
+		this.samlPurposeOfUseCSP = samlPurposeOfUseCSP;
+	}
+
+	public String getSamlPurposeOfUseValidatedAttributes() {
+		return samlPurposeOfUseValidatedAttributes;
+	}
+
+	public void setSamlPurposeOfUseValidatedAttributes(String samlPurposeOfUseValidatedAttributes) {
+		this.samlPurposeOfUseValidatedAttributes = samlPurposeOfUseValidatedAttributes;
+	}
+
+	public String getAttributeValue(String name) {
+		String rtn = null;
+		OMElement e = attributeStatement.get(name);
+		if (e != null) {
+			OMElement child = e.getFirstElement();
+			if (child != null) {
+				rtn = child.getText();
+			}
+		}
+		return rtn;
+	}
+
+	public String toString() {
+		return "RequestHeader: ";
+	}
+}

--- a/registry-msg-formats/src/main/java/gov/nist/toolkit/registrymsg/common/RequestHeaderParser.java
+++ b/registry-msg-formats/src/main/java/gov/nist/toolkit/registrymsg/common/RequestHeaderParser.java
@@ -1,0 +1,116 @@
+package gov.nist.toolkit.registrymsg.common;
+
+import gov.nist.toolkit.commondatatypes.MetadataSupport;
+import gov.nist.toolkit.utilities.xml.XmlUtil;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.xpath.AXIOMXPath;
+
+import javax.xml.namespace.QName;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+
+public class RequestHeaderParser {
+    OMElement ele;
+    RequestHeader header = new RequestHeader();
+
+
+    public RequestHeaderParser(OMElement ele) {
+        this.ele = ele;
+    }
+
+    public RequestHeader getRequestHeader() throws Exception {
+        parse();
+        return header;
+    }
+
+    public void parse() throws Exception {
+        String zz = ele.getLocalName();
+        if (!ele.getLocalName().equals("Header")) {
+            // Something is wrong
+            return;
+        }
+
+        AXIOMXPath xpathExpression = new AXIOMXPath ("//*[local-name()='Security']/*[local-name()='Assertion']/*[local-name()='AttributeStatement']");
+        Object o =  xpathExpression.selectSingleNode(ele);
+        if (o == null) return;
+        OMElement omEle = (OMElement) o;
+        Iterator<OMElement> iterator = omEle.getChildElements();
+        HashMap<String, OMElement> attributeListMap = new HashMap<>();
+        while (iterator.hasNext()) {
+            OMElement x = iterator.next();
+            String name = x.getAttributeValue(new QName("Name"));
+            attributeListMap.put(name, x.cloneOMElement());
+        }
+
+        header.omElement = omEle;
+        header.attributeStatement = attributeListMap;
+
+        header.samlAssertionID =                      evaluateXPath(ele, "//*[local-name()='Security']/*[local-name()='Assertion']", "ID");
+        header.samlAssertionIssueInstant =            evaluateXPath(ele, "//*[local-name()='Security']/*[local-name()='Assertion']", "IssueInstant");
+        header.samlAssertionVersion =                 evaluateXPath(ele, "//*[local-name()='Security']/*[local-name()='Assertion']", "Version");
+        header.samlAssertionIssuer =                  evaluateXPath(ele, "//*[local-name()='Security']/*[local-name()='Assertion']/*[local-name()='Issuer']");
+        header.samlCanonicalizationMethodAlgorithm =  evaluateXPath(ele, "//*[local-name()='Security']/*[local-name()='Assertion']/*[local-name()='Signature']/*[local-name()='SignedInfo']/*[local-name()='CanonicalizationMethod']", "Algorithm");
+        header.samlSignatureMethodAlgorithm =         evaluateXPath(ele, "//*[local-name()='Security']/*[local-name()='Assertion']/*[local-name()='Signature']/*[local-name()='SignedInfo']/*[local-name()='SignatureMethod']", "Algorithm");
+        header.samlDigestMethodAlgorithm =            evaluateXPath(ele, "//*[local-name()='Security']/*[local-name()='Assertion']/*[local-name()='Signature']/*[local-name()='SignedInfo']/*[local-name()='Reference']/*[local-name()='DigestMethod']", "Algorithm");
+        header.samlDigestValue =                      evaluateXPath(ele, "//*[local-name()='Security']/*[local-name()='Assertion']/*[local-name()='Signature']/*[local-name()='SignedInfo']/*[local-name()='Reference']/*[local-name()='DigestValue']");
+        header.samlSignatureValue =                   evaluateXPath(ele, "//*[local-name()='Security']/*[local-name()='Assertion']/*[local-name()='Signature']/*[local-name()='SignatureValue']");
+        header.samlX509Certificate =                  evaluateXPath(ele, "//*[local-name()='Security']/*[local-name()='Assertion']/*[local-name()='Signature']/*[local-name()='KeyInfo']/*[local-name()='X509Data']/*[local-name()='X509Certificate']");
+        header.samlRSAKyValueModulus =                evaluateXPath(ele, "//*[local-name()='Security']/*[local-name()='Assertion']/*[local-name()='Signature']/*[local-name()='KeyInfo']/*[local-name()='KeyValue']/*[local-name()='RSAKeyValue']/*[local-name()='Modulus']");
+        header.samlRSAKeyValueExponent =              evaluateXPath(ele, "//*[local-name()='Security']/*[local-name()='Assertion']/*[local-name()='Signature']/*[local-name()='KeyInfo']/*[local-name()='KeyValue']/*[local-name()='RSAKeyValue']/*[local-name()='Exponent']");
+
+        header.samlNHINHomeCommunityID = header.getAttributeValue("urn:nhin:names:saml:homeCommunityId");
+        header.samlIHEHomeCommunityID  = header.getAttributeValue("urn:ihe:iti:xca:2010:homeCommunityId");
+        header.samlPurposeOfUseCSP     = header.getAttributeValue("csp");
+        header.samlPurposeOfUseValidatedAttributes = header.getAttributeValue("validated_attributes");
+
+
+
+
+                System.out.println("SAML Assertion ID: " + header.samlAssertionID);
+    }
+
+    String evaluateXPath(OMElement ele, String expression) throws Exception  {
+        AXIOMXPath xpathExpression = new AXIOMXPath (expression);
+        Object o =  xpathExpression.selectSingleNode(ele);
+        if (o == null) return null;
+
+        OMElement omEle = (OMElement) o;
+        String rtn = omEle.getText();
+        return rtn;
+    }
+
+    String evaluateXPath(OMElement ele, String expression, String attribute) throws Exception  {
+        try {
+            AXIOMXPath xpathExpression = new AXIOMXPath(expression);
+            Object o = xpathExpression.selectSingleNode(ele);
+            if (o == null) return null;
+
+            OMElement omEle = (OMElement) o;
+            String rtn = null;
+            rtn = omEle.getAttributeValue(new QName(attribute));
+
+            return rtn;
+        } catch (Exception e) {
+            String z = e.toString();
+            throw e;
+        }
+    }
+
+    List<String> parseValueList(OMElement e, String xpath) throws Exception {
+        ArrayList<String> rtn = new ArrayList<>();
+
+        AXIOMXPath xpathExpression = new AXIOMXPath (xpath);
+        List<Object> objectList =  xpathExpression.selectNodes(ele);
+        if (objectList != null) {
+            for (Object o: objectList) {
+                OMElement omEle = (OMElement) o;
+                String text = omEle.getText();
+                rtn.add(text);
+            }
+        }
+        return rtn;
+    }
+}

--- a/test-engine/src/main/java/gov/nist/toolkit/testengine/engine/Validator.java
+++ b/test-engine/src/main/java/gov/nist/toolkit/testengine/engine/Validator.java
@@ -937,6 +937,9 @@ public class Validator {
 			case "AdhocQuery.DocumentEntry.patientId":
 				rtn = request.getPatientId();
 				break;
+			case "AdhocQuery.home":
+				rtn = request.getHome();
+				break;
 
 			default:
 				rtn = "Validator::extractNamedMetadata does not understand: " + metadataField;

--- a/utilities/src/main/java/gov/nist/toolkit/utilities/xml/XmlUtil.java
+++ b/utilities/src/main/java/gov/nist/toolkit/utilities/xml/XmlUtil.java
@@ -11,6 +11,7 @@ import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMFactory;
 import org.apache.axiom.om.OMNamespace;
 import org.apache.axiom.om.util.AXIOMUtil;
+import org.apache.axiom.om.xpath.AXIOMXPath;
 import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
@@ -374,5 +375,25 @@ public class XmlUtil {
       }
       return;
    }
+
+   public static String getStringFromXPath(OMElement element, String XPath) throws Exception{
+		String rtn = null;
+	   AXIOMXPath xpathExpression = new AXIOMXPath (XPath);
+	   Object o =  xpathExpression.selectSingleNode(element);
+	   if (o != null) {
+		   rtn = ((OMElement)o).getText();
+	   }
+	   return rtn;
+   }
+
+	public static String getStringFromXPath(OMElement element, String XPath, String attribute) throws Exception{
+		String rtn = null;
+		AXIOMXPath xpathExpression = new AXIOMXPath (XPath);
+		Object o =  xpathExpression.selectSingleNode(element);
+		if (o != null) {
+			rtn = ((OMElement)o).getAttributeValue(new QName(attribute));
+		}
+		return rtn;
+	}
 
 }

--- a/utilities/src/main/java/gov/nist/toolkit/utilities/xml/XmlUtil.java
+++ b/utilities/src/main/java/gov/nist/toolkit/utilities/xml/XmlUtil.java
@@ -396,4 +396,10 @@ public class XmlUtil {
 		return rtn;
 	}
 
+	public static OMElement getElementFromXPath(OMElement element, String XPath) throws Exception{
+		AXIOMXPath xpathExpression = new AXIOMXPath (XPath);
+		OMElement o = (OMElement) xpathExpression.selectSingleNode(element);
+		return o;
+	}
+
 }

--- a/xdstools2/src/main/webapp/toolkitx/testkit/plugins/SoapAssertion/SoapHeaderValidator.groovy
+++ b/xdstools2/src/main/webapp/toolkitx/testkit/plugins/SoapAssertion/SoapHeaderValidator.groovy
@@ -21,7 +21,7 @@ import org.apache.axiom.om.OMElement
 /**
  * Runs an MetadataContent validator through this plugin. @see Validator#run_test_assertions.
  */
-class StoredQueryValidator extends AbstractSoapValidater {
+class SoapHeaderValidator extends AbstractSoapValidater {
     /**
      * Required parameter
      */
@@ -45,14 +45,19 @@ class StoredQueryValidator extends AbstractSoapValidater {
     String codeValue
     String codingScheme
     String codeDisplayName
+    String XPath
+    String attribute
+    String section
+    String comment
+    String reference
 
     /**
      * Optional parameter
      */
     String metadataValidationFile;
 
-    StoredQueryValidator() {
-        filterDescription = 'Runs a StoredQuery validator (Validator#run_test_assertions) through this plugin.'
+    SoapHeaderValidator() {
+        filterDescription = 'Runs a Soap Header validator (Validator#run_test_assertions) through this plugin.'
     }
 
     @Override
@@ -76,11 +81,11 @@ class StoredQueryValidator extends AbstractSoapValidater {
                 RequestHeaderParser headerParser = new RequestHeaderParser(Util.parse_xml(sst.requestHeader))
                 RequestHeader requestHeader = headerParser.getRequestHeader()
                 String errors = "";
-                if (requestMsgExpectedContent.equals("StoredQuery")) {
+                if (requestMsgExpectedContent.equals("SoapHeader")) {
                     Validator v = new Validator().setRequest(r).setStoredQueryParams(params).setRequestHeader(requestHeader)
                     switch (method) {
                         case "single":
-                            if (!v.namedFieldCompare(key, value)) {
+                            if (!v.namedFieldCompare(key,section, XPath, attribute, comment, value)) {
                                 errors = v.getErrors()
                             }
                             break;
@@ -97,6 +102,21 @@ class StoredQueryValidator extends AbstractSoapValidater {
                         case "contains":
                             if (!v.namedFieldContains(key, value)) {
                                 errors = v.getErrors()
+                            }
+                            break;
+                        case "isPresent":
+                            if (!v.namedFieldIsPresent(key,section, XPath, attribute, comment)) {
+                                errors = v.getErrors();
+                            }
+                            break;
+                        case "isNotEmpty":
+                            if (!v.namedFieldIsNotEmpty(key,section, XPath, attribute, comment)) {
+                                errors = v.getErrors();
+                            }
+                            break;
+                        case "isNotPresent":
+                            if (!v.namedFieldIsNotPresent(key)) {
+                                errors = v.getErrors();
                             }
                             break;
                         default:
@@ -151,7 +171,7 @@ class StoredQueryValidator extends AbstractSoapValidater {
     }
 
     AbstractSoapValidater copy() {
-        StoredQueryValidator mcv = new StoredQueryValidator()
+        SoapHeaderValidator mcv = new SoapHeaderValidator()
         mcv.responseMsgExpectedContent = responseMsgExpectedContent
         mcv.requestMsgExpectedContent = requestMsgExpectedContent
         mcv.responseMsgECCount = responseMsgECCount

--- a/xdstools2/src/main/webapp/toolkitx/testkit/plugins/SoapAssertion/SoapHeaderValidator.groovy
+++ b/xdstools2/src/main/webapp/toolkitx/testkit/plugins/SoapAssertion/SoapHeaderValidator.groovy
@@ -76,13 +76,14 @@ class SoapHeaderValidator extends AbstractSoapValidater {
             if (sst.requestBody) {
                 ParamParser paramsParser = new ParamParser();
                 SqParams params = paramsParser.parse(Util.parse_xml(sst.requestBody), true);
-                AdhocQueryRequestParser parser = new AdhocQueryRequestParser(Util.parse_xml(sst.requestBody))
-                AdhocQueryRequest r = parser.getAdhocQueryRequest()
+//                AdhocQueryRequestParser parser = new AdhocQueryRequestParser(Util.parse_xml(sst.requestBody))
+//                AdhocQueryRequest r = parser.getAdhocQueryRequest()
                 RequestHeaderParser headerParser = new RequestHeaderParser(Util.parse_xml(sst.requestHeader))
                 RequestHeader requestHeader = headerParser.getRequestHeader()
                 String errors = "";
                 if (requestMsgExpectedContent.equals("SoapHeader")) {
-                    Validator v = new Validator().setRequest(r).setStoredQueryParams(params).setRequestHeader(requestHeader)
+//                    Validator v = new Validator().setRequest(r).setStoredQueryParams(params).setRequestHeader(requestHeader)
+                    Validator v = new Validator().setStoredQueryParams(params).setRequestHeader(requestHeader)
                     switch (method) {
                         case "single":
                             if (!v.namedFieldCompare(key,section, XPath, attribute, comment, value)) {

--- a/xdstools2/src/main/webapp/toolkitx/testkit/plugins/SoapAssertion/SoapHeaderValidator.groovy
+++ b/xdstools2/src/main/webapp/toolkitx/testkit/plugins/SoapAssertion/SoapHeaderValidator.groovy
@@ -105,7 +105,7 @@ class SoapHeaderValidator extends AbstractSoapValidater {
                             }
                             break;
                         case "isPresent":
-                            if (!v.namedFieldIsPresent(key,section, XPath, attribute, comment)) {
+                            if (!v.namedFieldIsPresent(key,section, XPath, comment)) {
                                 errors = v.getErrors();
                             }
                             break;


### PR DESCRIPTION
These changes are in support of #587.
I know the simulators perform some checks of headers when they accept transactions.
These changes allow us to write testplan.xml files that can test specific content after the fact using the pattern already established.

#588 and #589 were issues that came up while I was working on this branch and are all resolved with this code. When the PR is integrated, #587, #588 and #589 can all be closed.