### PR TITLE
Implement changes for issue 609 which controls the way DocumentEntry.…

### DIFF
--- a/config-datatypes/src/main/java/gov/nist/toolkit/configDatatypes/server/SimulatorProperties.java
+++ b/config-datatypes/src/main/java/gov/nist/toolkit/configDatatypes/server/SimulatorProperties.java
@@ -163,13 +163,13 @@ public class SimulatorProperties {
      * Endpoint to use to send the indicated transaction to this Simulator.
      * Updates to this property are ignored.
      */
-    public static final String                           xcqrEndpoint = "XCQR_endpoint";
+//    public static final String                           xcqrEndpoint = "XCQR_endpoint";
 
     /**
      * Endpoint to use to send the indicated transaction to this Simulator.
      * Updates to this property are ignored.
      */
-    public static final String                        xcqrTlsEndpoint = "XCQR_TLS_endpoint";
+//    public static final String                        xcqrTlsEndpoint = "XCQR_TLS_endpoint";
 
     /**
      * Endpoint to use to send the indicated transaction to this Simulator.
@@ -262,6 +262,12 @@ public class SimulatorProperties {
     public static final String                      metadataValidatorClass = "Register_Metadata_Validator_Class_Name";
 
     /**
+     * Colon separated list of validation rules to validate DocumentEntry.uniqueId on register transaction
+     */
+
+    public static final String                       METADATA_VALIDATION_DOCUMENT_ID_CODES = "Register_Metadata_Validation_Document_ID_Codes";
+
+    /**
      * Boolean property controlling whether a Registry Simulator should support the Extra Metadata option.
      */
     public static final String                 extraMetadataSupported = "Extra_Metadata_Supported";
@@ -280,14 +286,14 @@ public class SimulatorProperties {
     /**
      * The current index state of the content bundle. The index number is the item ordinal from the bundle index.
      */
-    public static final String                      currentContentBundleIdx = "Current Content Bundle Idx";
+//    public static final String                      currentContentBundleIdx = "Current Content Bundle Idx";
 
     /**
      * Content bundle
      * Should be in the format of "9999/Trans/ContentBundle" where 9999 is a test number.
      * @See https://bitbucket.org/iheos/toolkit/wiki/blog/odds_overview
      */
-    public static final String                      contentBundle = "Content Bundle";
+//    public static final String                      contentBundle = "Content Bundle";
     /**
      * Testplan to register On-Demand Document Entry and supply content
      * Look up will be in this order: "{Test plan#}/{section[0]}/ContentBundle" Example: 15812/Register_OD/ContentBundle

--- a/sim-common/src/main/java/gov/nist/toolkit/simcommon/server/factories/RegistryActorFactory.java
+++ b/sim-common/src/main/java/gov/nist/toolkit/simcommon/server/factories/RegistryActorFactory.java
@@ -108,6 +108,7 @@ public class RegistryActorFactory extends AbstractActorFactory implements IActor
             addFixedEndpoint(sc, SimulatorProperties.removeMetadataTlsEndpoint,    actorType, TransactionType.REMOVE_METADATA,     true);
 		}
 		addEditableConfig(sc, SimulatorProperties.metadataValidatorClass, ParamType.TEXT, "");
+		addEditableConfig(sc, SimulatorProperties.METADATA_VALIDATION_DOCUMENT_ID_CODES, ParamType.TEXT, "OID");
 		addEditableConfig(sc, SimulatorProperties.errors, ParamType.SELECTION, new ArrayList<String>(), false);
 
 		return new Simulator(sc);

--- a/simulators/src/main/java/gov/nist/toolkit/fhir/simulators/sim/reg/RegistryActorSimulator.java
+++ b/simulators/src/main/java/gov/nist/toolkit/fhir/simulators/sim/reg/RegistryActorSimulator.java
@@ -95,6 +95,11 @@ public class RegistryActorSimulator extends BaseDsActorSimulator {
 		return sce != null && sce.asBoolean();
 	}
 
+	private String metadataValidationDocumentIDCodes() {
+		SimulatorConfigElement sce = getSimulatorConfig().get(SimulatorProperties.METADATA_VALIDATION_DOCUMENT_ID_CODES);
+		return (sce == null) ? "" : sce.asString();
+	}
+
 	// this constructor must be used when running simulator
 	public RegistryActorSimulator(DsSimCommon dsSimCommon, SimulatorConfig simulatorConfig) {
 		super(dsSimCommon.simCommon, dsSimCommon);
@@ -148,6 +153,7 @@ public class RegistryActorSimulator extends BaseDsActorSimulator {
 			common.vc.isPartOfRecipient = isPartOfRecipient();   // part of implementation of Document Recipient
 			common.vc.isValidateCodes = isValidateCodes();
 			common.vc.validateAgainstPatientIdentityFeed = validateAgainstPatientIdentityFeed();
+			common.vc.metadataValidationDocumentIDCodes  = metadataValidationDocumentIDCodes();
 			common.vc.xds_b = true;
 			common.vc.isRequest = true;
 			common.vc.hasHttp = true;

--- a/simulators/src/main/java/gov/nist/toolkit/fhir/simulators/sim/rg/RGActorSimulator.groovy
+++ b/simulators/src/main/java/gov/nist/toolkit/fhir/simulators/sim/rg/RGActorSimulator.groovy
@@ -314,6 +314,7 @@ public class RGActorSimulator extends GatewaySimulatorCommon implements Metadata
             common.vc.hasHttp = true;
             common.vc.isPnR   = true;
             common.vc.isXCDR  = true;
+            common.vc.metadataValidationDocumentIDCodes  = metadataValidationDocumentIDCodes();
 
             if (!dsSimCommon.runInitialValidationsAndFaultIfNecessary())
                return false;  // returns if SOAP Fault was generated
@@ -507,6 +508,11 @@ public class RGActorSimulator extends GatewaySimulatorCommon implements Metadata
 
    public Metadata getMetadata() {
       return m;
+   }
+
+   private String metadataValidationDocumentIDCodes() {
+      SimulatorConfigElement sce = getSimulatorConfig().get(SimulatorProperties.METADATA_VALIDATION_DOCUMENT_ID_CODES);
+      return (sce == null) ? "" : sce.asString();
    }
 
 

--- a/validators-registry-metadata/src/main/java/gov/nist/toolkit/valregmetadata/validators/RegistryObjectValidator.java
+++ b/validators-registry-metadata/src/main/java/gov/nist/toolkit/valregmetadata/validators/RegistryObjectValidator.java
@@ -2,6 +2,8 @@ package gov.nist.toolkit.valregmetadata.validators;
 
 import gov.nist.toolkit.commondatatypes.MetadataSupport;
 import gov.nist.toolkit.errorrecording.ErrorRecorder;
+import gov.nist.toolkit.errorrecording.TextErrorRecorder;
+import gov.nist.toolkit.errorrecording.client.ValidatorErrorItem;
 import gov.nist.toolkit.errorrecording.client.XdsErrorCode;
 import gov.nist.toolkit.utilities.xml.XmlUtil;
 import gov.nist.toolkit.valregmetadata.datatype.CxFormat;
@@ -12,15 +14,15 @@ import gov.nist.toolkit.valregmetadata.model.*;
 import gov.nist.toolkit.valsupport.client.ValidationContext;
 import org.apache.axiom.om.OMElement;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.net.URISyntaxException;
+import java.util.*;
+import java.net.URI;
 
 /**
  *
  */
-public class RegistryObjectValidator {
+public class
+RegistryObjectValidator {
     AbstractRegistryObject mo;
     ObjectValidator ov;
 
@@ -89,33 +91,10 @@ public class RegistryObjectValidator {
         for (ExternalIdentifier ei : mo.getExternalIdentifiers()) {
             new ExternalIdentifierValidator(ei).validateStructure(er, vc);
             if (MetadataSupport.XDSDocumentEntry_uniqueid_uuid.equals(ei.getIdentificationScheme())) {
-                String[] parts = ei.getValue().split("\\^");
-                // Expecting an uniqueId to be in the format: OID^extension
-                // where OID = root.suffix (a length of 64 characters)
-                // where extension is 16 characters (CDA Document ID)
-                // In other words, a full-form of an uniqueId is: root.suffix^extension
-                new OidFormat(er, mo.identifyingString() + ": " + ei.identifyingString(), externalIdentifierDescription(desc, ei.getIdentificationScheme()))
-                        .validate(parts[0]);
-                /*
-                ITI TF 3
-                4.2.3.2.26 DocumentEntry.uniqueId
-                For documents using URIs, the uniqueId should be the URI, *except* for URNs with the “urn:oid:” and “urn:uuid:” namespaces.
-                -- This is why only the plain value is stored without the URI scheme.
-                ITI TF 3
-                Table 4.2.3.1.7-2: Data Types (previously Table 4.1-3)
-                Identifier data type:
-                when an OID format is specified, it shall follow the assignment and format rules defined for unique IDs in ITI TF-2x: Appendix B.
-                ITI TF 2x
-                Appendix B
-                B.3 UID Encoding Rules
-                UIDs shall not exceed 64 total characters, including the digits of each component, and separators between components.
-                 */
-                if (parts[0].length() > 64)
-                    er.err(XdsErrorCode.Code.XDSRegistryMetadataError, mo.identifyingString() + ": " + ei.identifyingString() + " OID part of DocumentEntry uniqueID is limited to 64 digits", this, resource);
-                if (parts.length > 1 && parts[1].length() > 16) {
-                    er.err(XdsErrorCode.Code.XDSRegistryMetadataError, mo.identifyingString() + ": " + ei.identifyingString() + " extension part of DocumentEntry uniqueID is limited to 16 characters", this, resource);
-                }
-
+                // Moved the code that was previously here to the method validateDocumentEntryUniqueId
+                // This was done to incorporate changes triggered by ITI CP 808 that allows
+                // different formats for DocumnentEntry.uniqueId
+                validateDocumentEntryUniqueId(er, vc, ei, desc, resource);
             } else if (MetadataSupport.XDSDocumentEntry_patientid_uuid.equals(ei.getIdentificationScheme())){
                 new CxFormat(er, mo.identifyingString() + ": " + ei.identifyingString(), "ITI TF-3: Table 4.1.7")
                         .validate(ei.getValue());
@@ -270,5 +249,145 @@ public class RegistryObjectValidator {
         return i;
     }
 
+    /* See IHE ITI CP-808.
+       DocumentEntry.uniqueId is now classified as an Identifier with this definition
+           A globally unique identifier. This may be one of OID, URI, UUID (as defined in this
+           table) or any other format that employs effective mechanisms to ensure global uniqueness.
+        The vc.metadataValidationDocumentIDCodes (String) is a simulator property that defines
+        how we should validate the DocumentEntry.uniqueId format
+            ""       This is the legacy mechanism. Validate as an OID
+            CP-808   Declare valid if encoded per any of OID, URI, UUID
+            a;b;c    The values for a,b,c are taken from "OID", "URI", "UUID".
+                     The user may specify any combination in any order.
+                     For example:  URI;OID
+                     The identifier is considered valid if it conforms to one of the
+                     encodings in the list. The delimiter is ; and not ,
+     */
+    private void validateDocumentEntryUniqueId(ErrorRecorder er, ValidationContext vc, ExternalIdentifier ei, ClassAndIdDescription desc, String resource) {
+        String resourceForDocumentEntryUniqueId = "ITI TF-3: 4.2.3.2.26";
+        List<String> validationCodes = new ArrayList<>();
+        Set<String> recognizedValidationCodes = new HashSet<>();
+        recognizedValidationCodes.add("OID");
+        recognizedValidationCodes.add("URI");
+        recognizedValidationCodes.add("UUID");
 
+        // Define a local variable and seed with legacy method if validation context does not provide a different value.
+        // The legacy method was originally defined for this identifier. ITI CP-808 expanded the definition, and that
+        // expanded definition is enabled by updating simulator configuration.
+        String validationMethods = ("".equals(vc.metadataValidationDocumentIDCodes)) ? "OID" : vc.metadataValidationDocumentIDCodes;
+        if ("NONE".equals(validationMethods)) {
+            // Special case where no validation is requested
+        } else if ("CP-808".equals(validationMethods)) {
+            // Shortcut for CP-808
+            validationCodes.add("OID");
+            validationCodes.add("URI");
+            validationCodes.add("UUID");
+        } else {
+            // Validation methods are codes separated by ;
+            String tokens[] = validationMethods.split(";");
+            for (int i = 0; i < tokens.length; i++) {
+                validationCodes.add(tokens[i]);
+            }
+        }
+
+        // Ensure that we recognize all validation codes
+        // If we don't, then there is a configuration error with the simulator
+        Iterator<String> it = validationCodes.iterator();
+        while (it.hasNext()) {
+            String encodingMethod = it.next();
+            if (! recognizedValidationCodes.contains(encodingMethod)) {
+                er.err(XdsErrorCode.Code.XDSRegistryMetadataError, mo.identifyingString() + ": " + ei.identifyingString() + " Unrecognized configuration code for Toolkit simulator: " + encodingMethod, this, resourceForDocumentEntryUniqueId);
+                er.err(XdsErrorCode.Code.XDSRegistryMetadataError, mo.identifyingString() + ": " + ei.identifyingString() + " Review/repair simulator configuration: " + vc.metadataValidationDocumentIDCodes, this, resourceForDocumentEntryUniqueId);
+            }
+        }
+
+        boolean isValidEncoding = false;
+        it = validationCodes.iterator();
+        while (it.hasNext() && !isValidEncoding) {
+            // Make a local recorder. We don't want to log errors in the full recorder
+            // until we are sure no validations complete successfully
+            ErrorRecorder localRecorder = new TextErrorRecorder();
+
+            String encodingMethod = it.next();
+
+            if ("OID".equals(encodingMethod)) {
+                isValidEncoding = isValidOID(ei, localRecorder, desc, resourceForDocumentEntryUniqueId);
+                if (isValidEncoding) {
+                    // Run a second time with the actual Error Recorder
+                    // This will pick up any warnings and report back
+                    // Loop will exit because 'isValidEncoding' is now true
+                    isValidOID(ei, er, desc, resourceForDocumentEntryUniqueId);
+                }
+            } else if ("URI".equals(encodingMethod)) {
+                isValidEncoding = isValidURI(ei, localRecorder, desc, resourceForDocumentEntryUniqueId);
+                if (isValidEncoding) {
+                    // Run a second time with the actual Error Recorder
+                    // This will pick up any warnings and report back
+                    // Loop will exit because 'isValidEncoding' is now true
+                    isValidURI(ei, er, desc, resourceForDocumentEntryUniqueId);
+                }
+            } else if ("UUID".equals(encodingMethod)) {
+                isValidEncoding = isValidUUID(ei, localRecorder, desc, resourceForDocumentEntryUniqueId);
+                    if (isValidEncoding) {
+                        // Run a second time with the actual Error Recorder
+                        // This will pick up any warnings and report back
+                        // Loop will exit because 'isValidEncoding' is now true
+                        isValidUUID(ei, er, desc, resourceForDocumentEntryUniqueId);
+                    }
+            } else {
+                // We flagged this error above
+            }
+        }
+
+        // If we did not find a valid encoding, run all validators again.
+        // In this loop, we use the actual error recorder so we can pass the error results back
+        if (! isValidEncoding) {
+            it = validationCodes.iterator();
+            while (it.hasNext() && !isValidEncoding) {
+                String encodingMethod = it.next();
+
+                if ("OID".equals(encodingMethod)) {
+                    isValidEncoding = isValidOID(ei, er, desc, resourceForDocumentEntryUniqueId);
+                } else if ("URI".equals(encodingMethod)) {
+                    isValidEncoding = isValidURI(ei, er, desc, resourceForDocumentEntryUniqueId);
+                } else if ("UUID".equals(encodingMethod)) {
+                    isValidEncoding = isValidUUID(ei, er, desc, resourceForDocumentEntryUniqueId);
+                } else {
+                    // We flagged this error above
+                }
+            }
+        }
+        if (! isValidEncoding) {
+            er.err(XdsErrorCode.Code.XDSRegistryMetadataError, mo.identifyingString() + ": " + ei.identifyingString() + " Validation of DocumentEntry.uniqueId failed for all configured validation methods: " + validationMethods, this, resourceForDocumentEntryUniqueId);
+        }
+    }
+
+    private boolean isValidOID(ExternalIdentifier ei, ErrorRecorder er, ClassAndIdDescription desc, String resource) {
+        String[] parts = ei.getValue().split("\\^");
+        OidFormat oidFormat = new OidFormat(er, mo.identifyingString() + ": " + ei.identifyingString(), externalIdentifierDescription(desc, ei.getIdentificationScheme()));
+        oidFormat.validate(parts[0]);
+
+        if (parts[0].length() > 64)
+            er.err(XdsErrorCode.Code.XDSRegistryMetadataError, mo.identifyingString() + ": " + ei.identifyingString() + " OID part of DocumentEntry uniqueID is limited to 64 digits", this, resource);
+        if (parts.length > 1 && parts[1].length() > 16) {
+            er.err(XdsErrorCode.Code.XDSRegistryMetadataError, mo.identifyingString() + ": " + ei.identifyingString() + " extension part of DocumentEntry uniqueID is limited to 16 characters", this, resource);
+        }
+
+        return ! er.hasErrors();
+    }
+    private boolean isValidURI(ExternalIdentifier ei, ErrorRecorder er, ClassAndIdDescription desc, String resource) {
+        String candidate = ei.getValue();
+        URI uri = null;
+        try {
+            uri = new URI(candidate);
+        } catch (URISyntaxException e) {
+            er.err(XdsErrorCode.Code.XDSRegistryMetadataError, mo.identifyingString() + ": " + ei.identifyingString() + " invalid syntax for URI per java.net.URI class: " + candidate, this, resource);
+        }
+        return ! er.hasErrors();
+    }
+    private boolean isValidUUID(ExternalIdentifier ei, ErrorRecorder er, ClassAndIdDescription desc, String resource) {
+        UuidFormat uuidFormat = new UuidFormat(er, mo.identifyingString(), resource);
+        uuidFormat.validate(ei.getValue());
+        return ! er.hasErrors();
+    }
 }

--- a/validators-support/src/main/java/gov/nist/toolkit/valsupport/client/ValidationContext.java
+++ b/validators-support/src/main/java/gov/nist/toolkit/valsupport/client/ValidationContext.java
@@ -83,6 +83,7 @@ public class ValidationContext  implements Serializable, IsSerializable {
 	public boolean isValidateCodes = true;
 	public boolean isPartOfRecipient = false;
 	public boolean validateAgainstPatientIdentityFeed = false;
+	public String metadataValidationDocumentIDCodes = "";
 
 	/**
 	 * Is this a Request? A setting of false does not mean that this is a
@@ -310,6 +311,7 @@ public class ValidationContext  implements Serializable, IsSerializable {
 		ccdaType = v.ccdaType;
 		codesFilename = v.codesFilename;
         forceMtom = v.forceMtom;
+		metadataValidationDocumentIDCodes = v.metadataValidationDocumentIDCodes;
 	}
 
 	public boolean hasMetadata() {
@@ -534,6 +536,9 @@ public class ValidationContext  implements Serializable, IsSerializable {
 			buf.append(";MetadataPatterns:").append(metadataPatterns);
 		if (ccdaType != null)
 			buf.append(";CCDA type is " + ccdaType);
+
+		if (metadataValidationDocumentIDCodes != null)
+			buf.append(";metadataValidationDocumentIDCodes:").append(metadataValidationDocumentIDCodes);
 
 		if (innerContexts != null) {
 			for (ValidationContext v : innerContexts) {

--- a/xdstools2/src/main/java/gov/nist/toolkit/xdstools2/client/GazelleXuaUsername.java
+++ b/xdstools2/src/main/java/gov/nist/toolkit/xdstools2/client/GazelleXuaUsername.java
@@ -59,7 +59,39 @@ public enum GazelleXuaUsername {
     secondpurposeofuseDOTOPERATIONSOID("secondpurposeofuse.OPERATIONSOID"),
     secondpurposeofuseDOTPAYMENTOID("secondpurposeofuse.PAYMENTOID"),
     secondpurposeofuseDOTPUBLICHEALTHOID("secondpurposeofuse.PUBLICHEALTHOID"),
-    secondpurposeofuseDOTREQUESTOID("secondpurposeofuse.REQUESTOID");
+    secondpurposeofuseDOTREQUESTOID("secondpurposeofuse.REQUESTOID"),
+
+    // Add entries for RCE 1.1 codes
+    secondpurposeofuseDOTTTRTMNT("secondpurposeofuse.T-TRTMNT"),
+    secondpurposeofuseDOTTPYMNT("secondpurposeofuse.T-PYMNT"),
+    secondpurposeofuseDOTTHCO("secondpurposeofuse.T-HCO"),
+    secondpurposeofuseDOTTPH("secondpurposeofuse.T-PH"),
+    secondpurposeofuseDOTTIAS("secondpurposeofuse.T-IAS"),
+    secondpurposeofuseDOTTGOVDTRM("secondpurposeofuse.T-GOVDTRM"),
+
+    // Add entries for RCE 2.0 codes
+    // The only difference between the 1.1 and 2.0 codes is for T-IAS.
+    // In the 1.1 specification, two attributes for csp and validated_attributes are added.
+    // In the 2.0 specification, an id_token is add (and csp and validated_attributes are omitted).
+    // The other 5 codes (T-TREAT, ...) are included for completeness.
+
+    secondpurposeofuseDOTTTRTMNT20("secondpurposeofuse.T-TRTMNT-20"),
+    secondpurposeofuseDOTTPYMNT20("secondpurposeofuse.T-PYMNT-20"),
+    secondpurposeofuseDOTTHCO20("secondpurposeofuse.T-HCO-20"),
+    secondpurposeofuseDOTTPH20("secondpurposeofuse.T-PH-20"),
+    secondpurposeofuseDOTTIAS20("secondpurposeofuse.T-IAS-20"),
+    secondpurposeofuseDOTTGOVDTRM20("secondpurposeofuse.T-GOVDTRM-20"),
+
+    // Add entries for ACP 1.0 testing.
+    // These track test patients because we need to include a patient ID
+    // that is specific to that test patient.
+
+    secondpurposeofuseDOTErnser("secondpurposeofuse.ACP-Ernser"),
+    secondpurposeofuseDOTSimonis("secondpurposeofuse.ACP-Simonis"),
+    secondpurposeofuseDOTOrn("secondpurposeofuse.ACP-Orn"),
+    secondpurposeofuseDOTWest("secondpurposeofuse.ACP-West"),
+    secondpurposeofuseDOTQuigley("secondpurposeofuse.ACP-Quigley"),
+    secondpurposeofuseDOTPredovic("secondpurposeofuse.ACP-Predovic");
 
     private String username;
 


### PR DESCRIPTION
…uniqueId is validated

Registry and Responding Gateway simulators are now augmented with a new configuration value. The configuration value contains one or more coded values that indicate how the uniqueId should be validated. Supported values are:
"" (empty) Defaults to legacy implementation; validate as an OID NONE Perform no validation
CP-808 Shortcut for OID;UUID;URI. Allows any of these to pass ; delimited list of allowed mechanisms. Values that go in the list are OID
UUID
URI