### PR TITLE
Repair for issue 620 requires repairing the value for <Test> in ...te…

### DIFF
--- a/xdstools2/src/main/webapp/toolkitx/testkit/utilities/FindDocuments2/XDS/testplan.xml
+++ b/xdstools2/src/main/webapp/toolkitx/testkit/utilities/FindDocuments2/XDS/testplan.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <TestPlan>
-    <Test>FindDocuments</Test>
+    <Test>FindDocuments2/XDS</Test>
     <TestStep id="object_refs">
         <ExpectedStatus>Success</ExpectedStatus>
         <StoredQueryTransaction>


### PR DESCRIPTION
…stkit/utilities/FindDocuments2/XDS/testplan.xml

The incorrect version meant that the metadata update code could not correctly find this test step.